### PR TITLE
Add Function and Tests to Extract Issue Numbers from a String

### DIFF
--- a/Sources/ChangelogProducerCore/StringExtensions.swift
+++ b/Sources/ChangelogProducerCore/StringExtensions.swift
@@ -14,9 +14,47 @@ extension String {
     func pullRequestIDs() -> [Int] {
         return []
     }
-
-    /// Extracts the resolved issue from a Pull Request body.
-    func resolvingIssue() -> Int? {
-        return nil
+    
+    /// Extracts the resolved issues from a Pull Request body.
+    func resolvingIssues() -> [Int] {
+        var resolvedIssues = Set<Int>()
+        
+        let splits = split(separator: "#")
+        
+        let issueClosingKeywords = [
+            "close ",
+            "closes ",
+            "closed ",
+            "fix ",
+            "fixes ",
+            "fixed ",
+            "resolve ",
+            "resolves ",
+            "resolved "
+        ]
+        
+        for (index, split) in splits.enumerated() {
+            let lowerCaseSplit = split.lowercased()
+            
+            for keyword in issueClosingKeywords {
+                if lowerCaseSplit.hasSuffix(keyword) {
+                    guard index + 1 <= splits.count - 1 else { break }
+                    let nextSplit = splits[index + 1]
+                    
+                    let numberPrefixString = nextSplit.prefix { (character) -> Bool in
+                        return character.isNumber
+                    }
+                    
+                    if !numberPrefixString.isEmpty, let numberPrefix = Int(numberPrefixString.description) {
+                        resolvedIssues.insert(numberPrefix)
+                        break
+                    } else {
+                        continue
+                    }
+                }
+            }
+        }
+                        
+        return Array(resolvedIssues)
     }
 }

--- a/Tests/ChangelogProducerTests/ChangelogProducerTests.swift
+++ b/Tests/ChangelogProducerTests/ChangelogProducerTests.swift
@@ -24,8 +24,6 @@ final class ChangelogProducerTests: XCTestCase {
 
     /// It should extract the fixed issue from the Pull Request body.
     func testResolvingReferencedIssue() {
-        // See this code as an example: https://github.com/fastlane/issue-bot/blob/457348717d99e5ffde34ca1619e7253ed51ec172/bot.rb#L456
-
         let issueClosingKeywords = [
             "close",
             "Closes",
@@ -37,12 +35,67 @@ final class ChangelogProducerTests: XCTestCase {
             "Resolves",
             "resolved"
         ]
+        
+        let issueNumber = 4343
 
         issueClosingKeywords.forEach { (closingKeyword) in
-            let description = examplePullRequestDescriptionUsing(closingKeyword: closingKeyword)
-            XCTAssertEqual(description.resolvingIssue(), 4343)
+            let description = examplePullRequestDescriptionUsing(closingKeyword: closingKeyword, issueNumber: issueNumber)
+            XCTAssertEqual(description.resolvingIssues(), [issueNumber])
         }
     }
+    
+    /// It should not extract anything if no issue number is found.
+    func testResolvingNoReferencedIssue() {
+        let description = examplePullRequestDescriptionUsing(closingKeyword: "fixes", issueNumber: nil)
+        XCTAssertTrue(description.resolvingIssues().isEmpty)
+    }
+    
+    /// It should not extract anything if no closing keywork is found.
+    func testResolvingNoClosingKeyword() {
+        let issueNumber = 4343
+
+        let description = examplePullRequestDescriptionUsing(closingKeyword: "", issueNumber: issueNumber)
+        XCTAssertTrue(description.resolvingIssues().isEmpty)
+    }
+    
+    /// It should extract mulitple issues.
+    func testResolvingMultipleIssues() {
+        let description = "This is a beautiful PR that close #123 for real. It also fixes #1 and fixes #2"
+        let resolvedIssues = description.resolvingIssues()
+        XCTAssertEqual(resolvedIssues.count, 3)
+        XCTAssertEqual(Set(description.resolvingIssues()), Set([123, 1, 2]))
+    }
+    
+    /// It should deduplicate if the same issue is closed multiple times.
+    func testResolvingMultipleIssuesDedup() {
+        let description = "This is a beautiful PR that close #123 for real. It also fixes #123"
+        XCTAssertEqual(description.resolvingIssues(), [123])
+    }
+    
+    /// It should not extract anything if there is no number after the #.
+    func testResolvingNoNumber() {
+        let description = "This is a beautiful PR that close # for real."
+        XCTAssertTrue(description.resolvingIssues().isEmpty)
+    }
+    
+    /// It should not extract anything if there is no number after the #, and it's at the end.
+    func testResolvingNoNumberLast() {
+        let description = "This is a beautiful PR that close #"
+        XCTAssertTrue(description.resolvingIssues().isEmpty)
+    }
+    
+    /// It should extract the issue if it's first.
+    func testResolvingIssueFirst() {
+        let description = "Resolves #123. Yay!"
+        XCTAssertEqual(description.resolvingIssues(), [123])
+    }
+    
+    /// It should extract the issue if it's the only thing present.
+    func testResolvingIssueOnly() {
+        let description = "Resolved #123"
+        XCTAssertEqual(description.resolvingIssues(), [123])
+    }
+
 
     static var allTests = [
         ("testPullRequestIDsFromSquashCommits", testPullRequestIDsFromSquashCommits),
@@ -52,11 +105,15 @@ final class ChangelogProducerTests: XCTestCase {
 }
 
 extension ChangelogProducerTests {
-    func examplePullRequestDescriptionUsing(closingKeyword: String) -> String {
+    func examplePullRequestDescriptionUsing(closingKeyword: String, issueNumber: Int?) -> String {
+        let issueNumberString = issueNumber?.description ?? ""
+        
         return """
             This PR does a lot of awesome stuff.
+            It even closes some issues!
+            Not #3737 though. This one is too hard.
 
-            \(closingKeyword) #4343
+            \(closingKeyword) #\(issueNumberString)
             """
 
     }


### PR DESCRIPTION
A few points:
- The function now returns an array of issues, since there could be more than one that's closed by the PR.
- I deduplicate extracted issues
- I added a bunch of test, let me know if I forgot something

You made this function an extension on String, but shouldn't it live on its own class instad?