### PR TITLE
Fix support for running tests on Linux

### DIFF
--- a/Tests/ChangelogProducerTests/XCTestManifests.swift
+++ b/Tests/ChangelogProducerTests/XCTestManifests.swift
@@ -1,9 +1,0 @@
-import XCTest
-
-#if !canImport(ObjectiveC)
-public func allTests() -> [XCTestCaseEntry] {
-    return [
-        // testCase(ChangelogProducerTests.allTests),
-    ]
-}
-#endif

--- a/Tests/LinuxMain.swift
+++ b/Tests/LinuxMain.swift
@@ -1,7 +1,1 @@
-import XCTest
-
-import ChangelogProducerTests
-
-var tests = [XCTestCaseEntry]()
-tests += ChangelogProducerTests.allTests()
-XCTMain(tests)
+fatalError("Running tests like this is unsupported. Run the tests again by using `swift test --enable-test-discovery`")


### PR DESCRIPTION
As of Swift 5.1 we can now run tests using a new command. This allows us to remove the `allTests` array properties.

See for more info: https://www.avanderlee.com/swift/creating-swift-package-manager-framework/